### PR TITLE
Add optional clusterrolebinding, fix account, indent

### DIFF
--- a/charts/backstage/templates/clusterrolebinding.yaml
+++ b/charts/backstage/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:aggregate-to-view
+{{- end }}

--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -50,7 +50,9 @@ spec:
           - name: app-config
             mountPath: /app/app-config.cm.yaml
             subPath: app-config.cm.yaml
+      {{- if .Values.serviceAccount.create }}
       serviceAccountName: backstage-service-account
+      {{- end }}
       volumes:
       - name: app-config
         configMap:

--- a/charts/backstage/templates/serviceaccount.yaml
+++ b/charts/backstage/templates/serviceaccount.yaml
@@ -1,4 +1,6 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: backstage-service-account
+{{- end }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -23,26 +23,29 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+clusterRoleBinding:
+  # Specifies whether a cluster role binding should be created
+  create: true
+
 podAnnotations: {}
 
 service:
   type: ClusterIP
   port: 7007
 
-resources: 
-   limits:
-     cpu: 1000m
-     memory: 512Mi
-   requests:
-     cpu: 100m
-     memory: 128Mi
+resources:
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
-
 
 github:
   accessToken: ""
@@ -59,7 +62,6 @@ catalog:
 
 backstage:
   baseURL: "http://localhost"
-
 
 appConfig: |
   organization:


### PR DESCRIPTION
This adds support for making the ClusterRoleBinding optional as these resources are not always available to create in all environments. It also adds a conditional for not using the service account if it is not created and some indent mismatches in
the values.yaml.