### PR TITLE
Allow mount of additional config maps as volumes

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -4,5 +4,5 @@ description: The Backstage Helm Chart
 
 type: application
 
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.16.0"

--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -47,14 +47,24 @@ spec:
             - configMapRef:
                 name: {{ include "backstage.name" . }}-config
           volumeMounts:
+          {{- range $k, $v := .Values.additionalConfigMapMounts }}
           - name: app-config
             mountPath: /app/app-config.cm.yaml
             subPath: app-config.cm.yaml
+          - mountPath: {{ $v.mountPath }}
+            name: {{ printf "additional-cm-%d" $k }}
+            subPath: {{ $v.subPath }}
+          {{- end }}
       serviceAccountName: backstage-service-account
       volumes:
       - name: app-config
         configMap:
           name: {{ include "backstage.name" . }}-app-config
+      {{- range $k, $v := .Values.additionalConfigMapMounts }}
+      - name: {{ printf "additional-cm-%d" $k }}
+        configMap:
+          name: {{ $v.configMap }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -43,6 +43,10 @@ tolerations: []
 
 affinity: {}
 
+additionalConfigMapMounts: []
+# - configMap: ca-bundle
+#   mountPath: /etc/ssl/bundle.pem
+#   subPath: bundle.pem
 
 github:
   accessToken: ""


### PR DESCRIPTION
If you want to use a database which requires SSL (like AWS rds) and you need to specify an additional CA, you can mount it as a config map (see the commented example in the `values.yaml`