### PR TITLE
fix: fix volume mounts range, allow default

### DIFF
--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -47,10 +47,10 @@ spec:
             - configMapRef:
                 name: {{ include "backstage.name" . }}-config
           volumeMounts:
-          {{- range $k, $v := .Values.additionalConfigMapMounts }}
           - name: app-config
             mountPath: /app/app-config.cm.yaml
             subPath: app-config.cm.yaml
+          {{- range $k, $v := .Values.additionalConfigMapMounts }}
           - mountPath: {{ $v.mountPath }}
             name: {{ printf "additional-cm-%d" $k }}
             subPath: {{ $v.subPath }}


### PR DESCRIPTION
Due to the range added recently, backstage does not start since the default app config CM volume mount doesn't get created unless additional configmap mounts are specified. 